### PR TITLE
network: rename create_ifcfg_{{ interface }} to avoid duplicate variable

### DIFF
--- a/salt/yomi/services/network.sls
+++ b/salt/yomi/services/network.sls
@@ -16,8 +16,8 @@ create_systemd_network_directory:
 # predictable network interface name, like Tumbleweed. For SLE, boot
 # the image with `net.ifnames=1`
 {% for interface in interfaces_except_lo %}
-{{ macros.log('file', 'create_ifcfg_' ~ interface) }}
-create_ifcfg_{{ interface }}:
+{{ macros.log('file', 'create_ifcfg_ifnames_' ~ interface) }}
+create_ifcfg_ifnames_{{ interface }}:
   file.append:
     - name: /mnt/etc/sysconfig/network/ifcfg-{{ interface }}
     - text: |


### PR DESCRIPTION
I tried yomi "manually" and through SUMA and I had this issue while I was trying to apply the highstate:
`Rendering SLS 'base:yomi.services.network' failed: while constructing a mapping\n  in \"<unicode string>\", line 7, column 1\nfound conflicting ID 'create_ifcfg_eth0'\n\\  in \"<unicode string>\", line 52, column 1`.

After having a look at the code, I saw that on some servers with only `eth*` network interfaces we can have duplicated variable names in L20 and L52. So I simply renamed one of the variable to avoid this case.